### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dls-controls/cs-web-striptool.git"
+    "url": "https://github.com/DiamondLightSource/cs-web-striptool.git"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.0",


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/cs-web-striptool` using https://gitlab.diamond.ac.uk/github/github-scripts